### PR TITLE
Replace 3.9-dev with 3.9 in .travis.yml to use Python 3.9 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - pypy3
   - nightly
   - 3.10-dev
-  - 3.9-dev
+  - 3.9
   - 3.8
   - 3.7
   - 3.6


### PR DESCRIPTION
because this repository was mentioned here:
https://github.com/hugovk/pypistats/issues/181